### PR TITLE
RegEx in cocal.php korrigiert

### DIFF
--- a/php/campus/cocal.php
+++ b/php/campus/cocal.php
@@ -215,7 +215,7 @@ if (isset($matrnr) && isset($passwd)) {
 
 				case 'LOCATION':
 					$matches = array();
-					if (preg_match('/^([0-9]+\|[0-9]+)/', $value, $matches)) {
+					if (preg_match('/^(([0-9]+\|[0-9]+)(\.[0-9]+)?)/', $value, $matches)) {
 						$room = $matches[1];
 						$address = get_address($db, $room);
 


### PR DESCRIPTION
Der aktuelle RegEx für die Raumnummern im Campus Kalender matcht keine Raumnummern wie z.B. 2350|314.1 (AH III, Informatikzentrum, https://www.campus.rwth-aachen.de/rwth/all/room.asp?room=2350%7C314%2E1).
Dadurch können keine Informationen für diese in den Kalender eingetragen werden.
Mit der Anpassung werden diese Nummern zusätzlich gematcht.